### PR TITLE
Add --use-hierarchy for memory.use_hierarchy, default value is 0

### DIFF
--- a/cgmanager.c
+++ b/cgmanager.c
@@ -1413,6 +1413,8 @@ static NihOption options[] = {
 		NULL, NULL, &daemonise, NULL },
 	{ 0, "sigstop", N_("Raise SIGSTOP when ready"),
 		NULL, NULL, &sigstop, NULL },
+	{ 0, "use-hierarchy", N_("Set memory.use_hierarchy"),
+		NULL, NULL, &use_hierarchy, NULL },
 
 	NIH_OPTION_LAST
 };

--- a/frontend.c
+++ b/frontend.c
@@ -25,6 +25,7 @@
 
 int daemonise = FALSE;
 int sigstop = FALSE;
+int use_hierarchy = FALSE;
 bool setns_pid_supported = false;
 unsigned long mypidns;
 bool setns_user_supported = false;

--- a/frontend.h
+++ b/frontend.h
@@ -70,6 +70,7 @@
 #ifndef __frontend_c
 extern int daemonise;
 extern int sigstop;
+extern int use_hierarchy;
 extern bool setns_pid_supported;
 extern unsigned long mypidns;
 extern bool setns_user_supported;

--- a/fs.c
+++ b/fs.c
@@ -390,7 +390,7 @@ static bool do_mount_subsys(int i)
 	if (strcmp(controller, "cpuset") == 0) {
 		set_clone_children(dest); // TODO make this optional?
 		nih_info(_("set clone_children"));
-	} else if (strcmp(controller, "memory") == 0) {
+	} else if (strcmp(controller, "memory") == 0 && use_hierarchy) {
 		set_use_hierarchy(dest);  // TODO make this optional?
 		nih_info(_("set memory.use_hierarchy"));
 	}


### PR DESCRIPTION
From [here](memory.use_hierarchy),by default, kernel disables the hierarchy feature. We shouldn't change memory.use_hierarchy default value.

On some old kernels below [3.16](https://github.com/torvalds/linux/commit/3dae7fec5e884a4e72e5416db0894de66f586201), once set memory.use_hierarchy of root cgroup to 1, memory.swappiness of children's cgroup can't be changed dynamically.

Signed-off-by: Ye Yin eyniy@qq.com
