### PR TITLE
sysvinit script hardcodes path to cgmanager as /sbin/cgmanager which breaks if elsewhere

### DIFF
--- a/config/init/sysvinit/cgmanager
+++ b/config/init/sysvinit/cgmanager
@@ -15,15 +15,15 @@
 
 # Do NOT "set -e"
 
-PATH=/sbin:/bin
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-DAEMON=/sbin/cgmanager
+DAEMON="$(which cgmanager)"
 NAME=cgmanager
 DESC="cgroup management daemon"
 
 BASEOPTS="--daemon -m name=systemd"
 
-test -x $DAEMON || exit 0
+test -x "$DAEMON" || exit 0
 
 PIDFILE=/run/$NAME.pid
 

--- a/config/init/sysvinit/cgmanager
+++ b/config/init/sysvinit/cgmanager
@@ -79,7 +79,7 @@ do_start()
 	# Kill any existing cgproxy
 	/etc/init.d/cgproxy stop >/dev/null 2>&1 || true
 	# check whether to start cgproxy or cgmanager
-	if /sbin/cgproxy --check-master; then
+	if cgproxy --check-master; then
 		NESTED=yes /etc/init.d/cgproxy start || true && { exit 0; }
 	fi
 

--- a/config/init/sysvinit/cgproxy
+++ b/config/init/sysvinit/cgproxy
@@ -15,15 +15,15 @@
 
 # Do NOT "set -e"
 
-PATH=/sbin:/bin
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-DAEMON=/sbin/cgproxy
+DAEMON="$(which cgproxy)"
 NAME=cgproxy
 DESC="cgroup management proxy daemon"
 
 BASEOPTS="--daemon"
 
-test -x $DAEMON || exit 0
+test -x "$DAEMON" || exit 0
 
 PIDFILE=/run/$NAME.pid
 


### PR DESCRIPTION
the sysvinit script for `cgmanager` calls `start-stop-daemon` with a fixed path of /sbin/cgmanager, which doesn't work on compiles that use `configure` default path `/usr/local/sbin/cgmanager` and thus require hand-modification.

I can think of two solutions:
1. use m4/autoconf to preprocess the init scripts and expand to the given --prefix during configure
2. try the standard paths at invocation time by using a standard $PATH instead of hardcoding full executable path, (preferring /usr/local, then /, then /usr as usual)
