### PR TITLE
fix: force libnih to use /run for pidfile

### DIFF
--- a/cgmanager-proxy.c
+++ b/cgmanager-proxy.c
@@ -1387,6 +1387,8 @@ main (int argc, char *argv[])
 
 	nih_main_init (argv[0]);
 
+	nih_main_set_pidfile (CGPROXY_PIDFILE);
+
 	nih_option_set_synopsis (_("Control group proxy"));
 	nih_option_set_help (_("The cgroup manager proxy"));
 

--- a/cgmanager.c
+++ b/cgmanager.c
@@ -1507,6 +1507,8 @@ main (int argc, char *argv[])
 	nih_option_set_synopsis (_("Control group manager"));
 	nih_option_set_help (_("The cgroup manager daemon"));
 
+	nih_main_set_pidfile (CGMANAGER_PIDFILE);
+
 	args = nih_option_parser (NULL, argc, argv, options, FALSE);
 	if (! args)
 		exit (1);

--- a/cgmanager.h
+++ b/cgmanager.h
@@ -7,3 +7,5 @@
 #define CGMANAGER_DBUS_PATH "unix:path=" CGMANAGER_SOCK
 #define CGPROXY_DBUS_PATH "unix:path=" CGPROXY_SOCK
 
+#define CGMANAGER_PIDFILE "/run/cgmanager.pid"
+#define CGPROXY_PIDFILE "/run/cgproxy.pid"


### PR DESCRIPTION
After unshare() and pivot_root() during daemonization, we do not take
/var in with us (only /, /proc, and /run)

Since no /var exists after pivot, this means /var/run will not exist if
it's on a separate mount point from /.  On contemporary systems for a
long while, /var/run is either a symlink or bind mount to /run anyways,
so we just tell libnih explicitly to use the pidfile in there rather
than using its default /var/run path (which won't work if /var is
separate anyways).

Patch originally submitted by rworkman@slackware.com, but they decided
to change libnih default to /run universally, so this patch wouldn't be
needed in that case (but wouldn't be a problem either).

Closes #22
