### PR TITLE
cgmanager does not clean up its mount point for cgmfs on exit

### DIFF
--- a/config/init/sysvinit/cgmanager
+++ b/config/init/sysvinit/cgmanager
@@ -15,17 +15,18 @@
 
 # Do NOT "set -e"
 
-PATH=/sbin:/bin
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-DAEMON=/sbin/cgmanager
+DAEMON="$(which cgmanager)"
 NAME=cgmanager
 DESC="cgroup management daemon"
 
 BASEOPTS="--daemon -m name=systemd"
 
-test -x $DAEMON || exit 0
+test -x "$DAEMON" || exit 0
 
 PIDFILE=/run/$NAME.pid
+CGMOUNT=/run/cgmanager/fs
 
 if [ -f /etc/default/cgmanager ]; then
 	# get cgmanager_opts if specified
@@ -64,6 +65,14 @@ do_stop()
 	[ "$?" = 2 ] && return 2
 	# Many daemons don't delete their pidfiles when they exit.
 	rm -f $PIDFILE
+
+	# cgmanager does not clean up the cgmfs mount point, so they
+	# stack up on top of each other every invocation if we do not
+	# try to unmount each stop (note: if we terminate outside
+	# control of this stop script, they will pile up anyways)
+	grep -q -m 1 "^cgmfs $CGMOUNT " /proc/self/mounts &&
+		umount $CGMOUNT
+
 	return "$RETVAL"
 }
 
@@ -79,7 +88,7 @@ do_start()
 	# Kill any existing cgproxy
 	/etc/init.d/cgproxy stop >/dev/null 2>&1 || true
 	# check whether to start cgproxy or cgmanager
-	if /sbin/cgproxy --check-master; then
+	if cgproxy --check-master; then
 		NESTED=yes /etc/init.d/cgproxy start || true && { exit 0; }
 	fi
 


### PR DESCRIPTION
```
$ pgrep cgmanager || grep ^cgmfs /proc/self/mounts || echo cgoff
cgoff

$ for ((i = 0; i < 3; i++)); do
     sudo service cgmanager start
     sudo service cgmanager stop
  done >/dev/null

$ mount | grep ^cgmfs
cgmfs on /run/cgmanager/fs type tmpfs (rw,relatime,size=100k,mode=755)
cgmfs on /run/cgmanager/fs type tmpfs (rw,relatime,size=100k,mode=755)
cgmfs on /run/cgmanager/fs type tmpfs (rw,relatime,size=100k,mode=755)
```

these will accumulate to as many as there are `$i` in the above.
