### PR TITLE
check for NULL pointer returned by pam_get_data() in session close

### DIFF
--- a/pam/pam_cgm.c
+++ b/pam/pam_cgm.c
@@ -843,7 +843,9 @@ int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc,
 	if (ret != PAM_SUCCESS) {
 		mysyslog(LOG_ERR, "cannot get handle data (%d)\n", ret);
 		return ret;
-	} else
+	} else if (hd_ptr == NULL)
+		return PAM_SUCCESS;
+	else
 		hd = (struct handle_data *)hd_ptr;
 
 	if (!hd->session_open) {


### PR DESCRIPTION
It turns out that PAM can call module pam_sm_close_session() function even
though this module pam_sm_open_session() returned an error.

In this case pam_get_data() in pam_sm_close_session() will return NULL - we
need to check for that.
